### PR TITLE
Tabbing mechanism was overwriting every anchor

### DIFF
--- a/src/libs/ADF/ng/directives/tab-set.html
+++ b/src/libs/ADF/ng/directives/tab-set.html
@@ -1,8 +1,7 @@
-<div>
+<div ng-transclude>
 	<ul class="temui-tab-titles">
 		<li ng-repeat="tab in tabs">
-			<a href="#{{tab.id}}" class="temui-tab-heading">{{tab.heading}}</a>
+			<a class="tabanchor" href="#{{tab.id}}">{{tab.heading}}</a>
 		</li>
 	</ul>
-	<div ng-transclude />
 </div>

--- a/src/libs/ADF/ng/directives/tabs.js
+++ b/src/libs/ADF/ng/directives/tabs.js
@@ -64,13 +64,16 @@ define(['angular', 'jquery', 'text!./tab-set.html', '../adf-ng-module', 'adf-ui'
                 // been set to its real value at this time.
                 $timeout(function(){
                     // fix for IE7
-                    $(elem).find('a.temui-tab-heading').each(function(){
-                        if ($(this).attr('href').split('#').length > 1){
-                           $(this).attr('href', '#' + $(this).attr('href').split('#')[1]); 
-                        }
+                    elem.find('.tabanchor').each(function(){
+						try {
+	                        $(this).attr('href', '#' + $(this).attr('href').split('#')[1]);
+						} catch(e) {
+							// Catch the exception that happens on IE11.
+							var failtest = {};
+						}                    	
                     });
-                    $(elem).tabs();
-                    $(elem).bind('tabsshow', function(event, ui) {
+                    elem.tabs();
+                    elem.bind('tabsshow', function(event, ui) {
                         for (var i = 0; i < $scope.tabs.length; i++) {
                             if ('#' + $scope.tabs[i].id == $(ui.tab).attr('href')) {
                                 $scope.tabs[i].setActive(true);
@@ -83,7 +86,7 @@ define(['angular', 'jquery', 'text!./tab-set.html', '../adf-ng-module', 'adf-ui'
 
                 $scope.$watch('tabs.length', function(newValue, oldValue, scope) {
                     $timeout(function(){
-                        $(elem).tabs('refresh');
+                        elem.tabs('refresh');
                     });
                 });
             }
@@ -108,7 +111,7 @@ define(['angular', 'jquery', 'text!./tab-set.html', '../adf-ng-module', 'adf-ui'
     <div ng-controller="MainController">
         Tab 1 is selected: {{tab1Active}}
         <div adf-tab-set>
-            <div adf-tab heading="Tab 1" active="$parent.tab1Active">
+            <div adf-tab heading="Tab 1" active="tab1Active">
                 Tab 1 content
             </div>
             <div adf-tab heading="Tab 2" select="tab2Selected()">
@@ -138,16 +141,13 @@ define(['angular', 'jquery', 'text!./tab-set.html', '../adf-ng-module', 'adf-ui'
             replace: true,
             template: '<div ng-transclude />',
             link: function ($scope, elem, attrs, tabSetContainer) {
+
                 $scope.setActive = function(active){
-                    if (attrs.active){
-                        $scope.$apply(function(){
-                            $scope.active = active;
-                        });
-                    }
+                    if (attrs.active)
+                        $scope.active = active;
                     if (active){
                         $scope.onSelect();
                         $scope.$$nextSibling.$broadcast('adfTabSelected', $scope.id);
-                        $(window).trigger('resize');
                     }
                 };
 

--- a/src/libs/angular/angular.js
+++ b/src/libs/angular/angular.js
@@ -67,6 +67,15 @@ var /** holds major version number for IE or NaN for real browsers */
     nodeName_,
     uid               = ['0', '0', '0'];
 
+/** 
+ * Fix for problem with Console. The Console will always send a header to the server indicating IE7.
+ * The override of the IE rendering engine version using the meta tag
+ * <meta http-equiv="X-UA-Compatible" content="IE=9">
+ * has no effect on the useragent header sent by the browser to the server, but does change the documentMode.
+ */
+if (! isNaN(msie)) {
+	msie = document.documentMode;
+}
 
 /**
  * @private

--- a/src/libs/angular/angular.js
+++ b/src/libs/angular/angular.js
@@ -67,15 +67,6 @@ var /** holds major version number for IE or NaN for real browsers */
     nodeName_,
     uid               = ['0', '0', '0'];
 
-/** 
- * Fix for problem with Console. The Console will always send a header to the server indicating IE7.
- * The override of the IE rendering engine version using the meta tag
- * <meta http-equiv="X-UA-Compatible" content="IE=9">
- * has no effect on the useragent header sent by the browser to the server, but does change the documentMode.
- */
-if (! isNaN(msie)) {
-	msie = document.documentMode;
-}
 
 /**
  * @private


### PR DESCRIPTION
Tabbing mechanism was overwriting every anchor, not just the ones it was meant to.

Changed the selector to work on class, not tag type.
